### PR TITLE
feat: Add resources and configurations for container deployment

### DIFF
--- a/iac/locals.tf
+++ b/iac/locals.tf
@@ -1,3 +1,5 @@
+data "azapi_client_config" "current" {}
+
 locals {
   appname        = "azapi-ephemeral-demo"
   default_suffix = "${local.appname}-${var.env_code}"
@@ -9,9 +11,7 @@ locals {
 
   # add resource names here, using CAF-aligned naming conventions
   resource_group_name = "rg-${local.default_suffix}"
-
-  # tflint-ignore: terraform_unused_declarations
-  location = data.azurerm_resource_group.parent.location
+  resource_group_id   = "/subscriptions/${data.azapi_client_config.current.subscription_id}/resourceGroups/${local.resource_group_name}"
 
   # tflint-ignore: terraform_unused_declarations
   default_tags = merge(

--- a/iac/main.tf
+++ b/iac/main.tf
@@ -1,4 +1,91 @@
-# Get info about the resource group the solution is deployed into
-data "azurerm_resource_group" "parent" {
-  name = local.resource_group_name
+resource "random_string" "container_name" {
+  length  = 25
+  lower   = true
+  upper   = false
+  special = false
+}
+
+resource "azapi_resource" "log_analytics_workspace" {
+  type      = "Microsoft.OperationalInsights/workspaces@2025-02-01"
+  name      = "law-${var.container_group_name_prefix}-${random_string.container_name.result}"
+  location  = var.location
+  parent_id = local.resource_group_id
+  body = {
+    properties = {
+      sku = {
+        name = "PerGB2018"
+      }
+      retentionInDays = 30
+    }
+  }
+  tags = local.default_tags
+}
+
+ephemeral "azapi_resource_action" "law_shared_key" {
+  action                 = "sharedKeys"
+  method                 = "POST"
+  resource_id            = azapi_resource.log_analytics_workspace.output.id
+  type                   = "Microsoft.OperationalInsights/workspaces@2020-08-01"
+  response_export_values = ["primarySharedKey"]
+}
+
+resource "azapi_resource" "container" {
+  type      = "Microsoft.ContainerInstance/containerGroups@2023-05-01"
+  name      = "${var.container_group_name_prefix}-${random_string.container_name.result}"
+  location  = var.location
+  parent_id = local.resource_group_id
+  body = {
+    properties = {
+      containers = [
+        {
+          name = "${var.container_name_prefix}-${random_string.container_name.result}"
+          properties = {
+            image = var.image
+            resources = {
+              requests = {
+                cpu        = var.cpu_cores
+                memoryInGB = var.memory_in_gb
+              }
+            }
+            ports = [
+              {
+                port     = var.port
+                protocol = "TCP"
+              }
+            ]
+          }
+        }
+      ]
+      diagnostics = {
+        logAnalytics = {
+          logType             = "ContainerInsights"
+          workspaceId         = azapi_resource.log_analytics_workspace.output.properties.customerId
+          workspaceResourceId = azapi_resource.log_analytics_workspace.output.id
+        }
+      }
+      osType        = "Linux"
+      restartPolicy = var.restart_policy
+      ipAddress = {
+        type = "Public"
+        ports = [
+          {
+            port     = var.port
+            protocol = "TCP"
+          }
+        ]
+      }
+    }
+  }
+  response_export_values = ["properties.ipAddress.ip"]
+  sensitive_body = {
+    properties = {
+      diagnostics = {
+        logAnalytics = {
+          workspaceKey = ephemeral.azapi_resource_action.law_shared_key.output.primarySharedKey
+        }
+      }
+    }
+  }
+  schema_validation_enabled = false
+  tags                      = local.default_tags
 }

--- a/iac/outputs.tf
+++ b/iac/outputs.tf
@@ -1,3 +1,7 @@
 output "resource_group_name" {
   value = local.resource_group_name
 }
+
+output "container_ipv4_address" {
+  value = azapi_resource.container.output.properties.ipAddress.ip
+}

--- a/iac/terraform.tf
+++ b/iac/terraform.tf
@@ -4,34 +4,18 @@ terraform {
   required_providers {
     # The root of the configuration where Terraform Apply runs should specify the maximum allowed provider version.
     # https://developer.hashicorp.com/terraform/language/providers/requirements#best-practices-for-provider-versions  
-    azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "~> 4.7"
+    azapi = {
+      source  = "azure/azapi"
+      version = "~> 2.4"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.7"
     }
   }
 
 }
 
-provider "azurerm" {
-  # By default, all resource providers will be enabled in the subscription when Terraform first runs
-  # security recommendations are to only enable the providers that are required.
-  # AzureRM v4 version:
-  resource_provider_registrations = "none"
-  # AzureRM v3 version:
-  # skip_provider_registration = true
-
-  storage_use_azuread = true
-
-  features {
-    resource_group {
-      prevent_deletion_if_contains_resources = false # This is to handle MCAPS or other policy driven resource creation.
-    }
-
-    # some default safety features for Key Vault
-    key_vault {
-      purge_soft_delete_on_destroy    = false
-      recover_soft_deleted_key_vaults = true
-    }
-  }
+provider "azapi" {
+  enable_preflight = true
 }
-

--- a/iac/variables.container_groups.tf
+++ b/iac/variables.container_groups.tf
@@ -20,6 +20,11 @@ variable "port" {
   type        = number
   description = "Port to open on the container and the public IP address."
   default     = 80
+
+  validation {
+    condition     = var.port > 0 && var.port <= 65535
+    error_message = "The port must be a number between 1 and 65535."
+  }
 }
 
 variable "cpu_cores" {

--- a/iac/variables.container_groups.tf
+++ b/iac/variables.container_groups.tf
@@ -1,0 +1,45 @@
+variable "container_group_name_prefix" {
+  type        = string
+  description = "Prefix of the container group name that's combined with a random value so name is unique in your Azure subscription."
+  default     = "acigroup"
+}
+
+variable "container_name_prefix" {
+  type        = string
+  description = "Prefix of the container name that's combined with a random value so name is unique in your Azure subscription."
+  default     = "aci"
+}
+
+variable "image" {
+  type        = string
+  description = "Container image to deploy. Should be of the form repoName/imagename:tag for images stored in public Docker Hub, or a fully qualified URI for other registries. Images from private registries require additional registry credentials."
+  default     = "mcr.microsoft.com/azuredocs/aci-helloworld"
+}
+
+variable "port" {
+  type        = number
+  description = "Port to open on the container and the public IP address."
+  default     = 80
+}
+
+variable "cpu_cores" {
+  type        = number
+  description = "The number of CPU cores to allocate to the container."
+  default     = 1
+}
+
+variable "memory_in_gb" {
+  type        = number
+  description = "The amount of memory to allocate to the container in gigabytes."
+  default     = 2
+}
+
+variable "restart_policy" {
+  type        = string
+  description = "The behavior of Azure runtime if container has stopped."
+  default     = "Always"
+  validation {
+    condition     = contains(["Always", "Never", "OnFailure"], var.restart_policy)
+    error_message = "The restart_policy must be one of the following: Always, Never, OnFailure."
+  }
+}

--- a/iac/variables.tf
+++ b/iac/variables.tf
@@ -48,3 +48,9 @@ DESCRIPTION
   type        = map(string)
   default     = {}
 }
+
+variable "location" {
+  description = "The Azure region where resources will be deployed."
+  type        = string
+  default     = "australiaeast"
+}


### PR DESCRIPTION
This pull request introduces significant updates to the Terraform configuration for deploying Azure resources. The changes include transitioning from the `azurerm` provider to the `azapi` provider, adding support for container groups and Log Analytics workspaces, and defining new variables to enhance configurability. Below are the most important changes grouped by theme:

### Provider Migration and Configuration:
* Replaced the `azurerm` provider with the `azapi` provider and added the `random` provider for generating unique names. Removed the `azurerm` provider's configuration and introduced `azapi` provider-specific settings. (`iac/terraform.tf`, [iac/terraform.tfL7-L37](diffhunk://#diff-68e947293fa62764b9e7cf3643f839d4f0d584432f31c825a42bda994010f2c1L7-L37))

### Resource Definitions:
* Added a new `random_string` resource to generate unique container names. (`iac/main.tf`, [iac/main.tfL1-R90](diffhunk://#diff-ffb4ef0f86f33ac18c5ca4f591e1ee94b1ee02efae76d9bc7d5935412c2410bbL1-R90))
* Defined an `azapi_resource` for creating a Log Analytics workspace with a retention policy and diagnostic settings. (`iac/main.tf`, [iac/main.tfL1-R90](diffhunk://#diff-ffb4ef0f86f33ac18c5ca4f591e1ee94b1ee02efae76d9bc7d5935412c2410bbL1-R90))
* Added an `azapi_resource` for deploying container groups with diagnostics integrated into the Log Analytics workspace. (`iac/main.tf`, [iac/main.tfL1-R90](diffhunk://#diff-ffb4ef0f86f33ac18c5ca4f591e1ee94b1ee02efae76d9bc7d5935412c2410bbL1-R90))

### Outputs:
* Introduced a new output, `container_ipv4_address`, to expose the IP address of the deployed container group. (`iac/outputs.tf`, [iac/outputs.tfR4-R7](diffhunk://#diff-7bf9cc4445e91b3fe608da0ae5a8662f3ad36ac15cddd57a7d95ddae44d9e477R4-R7))

### Variables:
* Added new variables for container group configuration, including `container_group_name_prefix`, `container_name_prefix`, `image`, `port`, `cpu_cores`, `memory_in_gb`, and `restart_policy`. These variables improve flexibility and allow customization of container deployments. (`iac/variables.container_groups.tf`, [iac/variables.container_groups.tfR1-R45](diffhunk://#diff-6e25e484436c876154e79ac5c51090e530a865039e027a61802f275fb8be9354R1-R45))
* Added a `location` variable to specify the Azure region for resource deployment. (`iac/variables.tf`, [iac/variables.tfR51-R56](diffhunk://#diff-e8d371653bf2fbe8f9cbfbac9d73752d08ed7f41830b45e280ec4017d90bed49R51-R56))

### Refactoring:
* Simplified resource group handling by removing the `azurerm_resource_group` data source and replacing it with direct references to the `azapi_client_config` data source for subscription and resource group IDs. (`iac/locals.tf`, [[1]](diffhunk://#diff-a376ce060d3713cf0114b14e68aade4fd4f41c9da8f0c4b187c6e8d9b733630fR1-R2) [[2]](diffhunk://#diff-a376ce060d3713cf0114b14e68aade4fd4f41c9da8f0c4b187c6e8d9b733630fL12-R14)